### PR TITLE
Add terraform plan

### DIFF
--- a/deployment/common.auto.tfvars
+++ b/deployment/common.auto.tfvars
@@ -1,0 +1,13 @@
+charm = {
+  name  = "hook-service"
+  units = 1
+  base  = "ubuntu@22.04"
+  trust = true
+  config = {
+    "salesforce_domain" : "https://canonicalhr--staging.sandbox.my.salesforce.com",
+    "salesforce_enabled" : true,
+    "https_proxy" : "http://squid.ps6.internal:3128",
+    "http_proxy" : "http://squid.ps6.internal:3128",
+    "no_proxy" : "10.142.140.0/24,10.100.0.0/16,10.200.0.0/16,localhost,127.0.0.1,0.0.0.0,ppa.launchpad.net,launchpad.net,canonical.com,gcr.io,svc.cluster.local"
+  }
+}

--- a/deployment/main.tf
+++ b/deployment/main.tf
@@ -1,0 +1,77 @@
+terraform {
+  required_providers {
+    juju = {
+      version = ">= 0.15.0"
+      source  = "juju/juju"
+    }
+  }
+}
+
+variable "client_id" {
+  type      = string
+  sensitive = true
+}
+
+variable "client_secret" {
+  type      = string
+  sensitive = true
+}
+
+variable "jimm_url" {
+  type = string
+}
+
+variable "model" {
+  type = string
+}
+
+variable "charm" {
+  description = "The configurations of the application."
+  type = object({
+    units  = optional(number, 1)
+    base   = optional(string, "ubuntu@22.04")
+    trust  = optional(string, true)
+    config = optional(map(string), {})
+  })
+  default = {}
+}
+
+variable "application_name" {
+  type = string
+}
+
+variable "revision" {
+  type = number
+}
+
+variable "channel" {
+  type = string
+}
+
+provider "juju" {
+  controller_addresses = var.jimm_url
+
+  client_id     = var.client_id
+  client_secret = var.client_secret
+
+}
+
+data "juju_secret" "salesforce_consumer_secret" {
+  // The secret is created when we deploy the service. The name must be
+  // the same with whatever we have in
+  // https://github.com/canonical/cd-identity-core-infrastructure/blob/main/modules/hook_service/main.tf
+  name  = "hook_salesforce_service_credentials"
+  model = var.model
+}
+
+module "application" {
+  source                           = "../terraform"
+  model_name                       = var.model
+  app_name                         = var.application_name
+  units                            = var.charm.units
+  base                             = var.charm.base
+  config                           = var.charm.config
+  salesforce_credentials_secret_id = sensitive(data.juju_secret.salesforce_consumer_secret.secret_id)
+  channel                          = var.channel
+  revision                         = var.revision
+}

--- a/terraform/.terraform-docs.yaml
+++ b/terraform/.terraform-docs.yaml
@@ -1,0 +1,17 @@
+formatter: markdown table
+
+header-from: main.tf
+
+content: |-
+  {{ .Header }}
+  ---
+  {{ .Providers }}
+  ---
+  {{ .Requirements }}
+  ---
+  {{ .Inputs }}
+  ---
+  {{ .Outputs }}
+
+sort:
+  enabled: false

--- a/terraform/MODULE_SPECS.md
+++ b/terraform/MODULE_SPECS.md
@@ -1,0 +1,41 @@
+<!-- BEGIN_TF_DOCS -->
+# Terraform Module for Hook Service K8s Operator
+
+This is a Terraform module facilitating the deployment of the
+hook-service charm using the Juju Terraform provider.
+---
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_juju"></a> [juju](#provider\_juju) | >= 0.16.0 |
+---
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.0 |
+| <a name="requirement_juju"></a> [juju](#requirement\_juju) | >= 0.16.0 |
+---
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_model_name"></a> [model\_name](#input\_model\_name) | The Juju model name | `string` | n/a | yes |
+| <a name="input_app_name"></a> [app\_name](#input\_app\_name) | The Juju application name | `string` | n/a | yes |
+| <a name="input_config"></a> [config](#input\_config) | The charm config | `map(string)` | `{}` | no |
+| <a name="input_constraints"></a> [constraints](#input\_constraints) | The constraints to be applied | `string` | `"arch=amd64"` | no |
+| <a name="input_units"></a> [units](#input\_units) | The number of units | `number` | `1` | no |
+| <a name="input_base"></a> [base](#input\_base) | The charm base | `string` | `"ubuntu@22.04"` | no |
+| <a name="input_channel"></a> [channel](#input\_channel) | The charm channel | `string` | `"latest/edge"` | no |
+| <a name="input_revision"></a> [revision](#input\_revision) | The charm revision | `number` | `null` | no |
+| <a name="input_salesforce_credentials_secret_id"></a> [salesforce\_credentials\_secret\_id](#input\_salesforce\_credentials\_secret\_id) | The juju secret with credentials for calling the Salesforce API. | `string` | n/a | yes |
+---
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_app_name"></a> [app\_name](#output\_app\_name) | The Juju application name |
+| <a name="output_requires"></a> [requires](#output\_requires) | The Juju integrations that the charm requires |
+| <a name="output_provides"></a> [provides](#output\_provides) | The Juju integrations that the charm provides |
+<!-- END_TF_DOCS -->

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,25 @@
+/**
+ * # Terraform Module for Hook Service K8s Operator
+ *
+ * This is a Terraform module facilitating the deployment of the
+ * hook-service charm using the Juju Terraform provider.
+ */
+
+resource "juju_application" "application" {
+  name  = var.app_name
+  model = var.model_name
+  trust = true
+  config = merge(
+    var.config,
+    { salesforce_consumer_secret = format("secret:%s", var.salesforce_credentials_secret_id) }
+  )
+  constraints = var.constraints
+  units       = var.units
+
+  charm {
+    name     = "hook-service"
+    base     = var.base
+    channel  = var.channel
+    revision = var.revision
+  }
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,24 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+output "app_name" {
+  description = "The Juju application name"
+  value       = juju_application.application.name
+}
+
+output "requires" {
+  description = "The Juju integrations that the charm requires"
+  value = {
+    logging = "logging"
+    tracing = "tracing"
+  }
+}
+
+output "provides" {
+  description = "The Juju integrations that the charm provides"
+  value = {
+    hydra-token-hook  = "hydra-token-hook"
+    metrics-endpoint  = "metrics-endpoint"
+    grafana-dashboard = "grafana-dashboard"
+  }
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,55 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+variable "model_name" {
+  description = "The Juju model name"
+  type        = string
+}
+
+variable "app_name" {
+  description = "The Juju application name"
+  type        = string
+}
+
+variable "config" {
+  description = "The charm config"
+  type        = map(string)
+  default     = {}
+}
+
+variable "constraints" {
+  description = "The constraints to be applied"
+  type        = string
+  default     = "arch=amd64"
+}
+
+variable "units" {
+  description = "The number of units"
+  type        = number
+  default     = 1
+}
+
+variable "base" {
+  description = "The charm base"
+  type        = string
+  default     = "ubuntu@22.04"
+}
+
+variable "channel" {
+  description = "The charm channel"
+  type        = string
+  default     = "latest/edge"
+}
+
+variable "revision" {
+  description = "The charm revision"
+  type        = number
+  nullable    = true
+  default     = null
+}
+
+variable "salesforce_credentials_secret_id" {
+  description = "The juju secret with credentials for calling the Salesforce API."
+  type        = string
+  sensitive   = true
+}

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -1,0 +1,13 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+terraform {
+  required_providers {
+    juju = {
+      source  = "juju/juju"
+      version = ">= 0.16.0"
+    }
+  }
+
+  required_version = ">= 1.5.0"
+}


### PR DESCRIPTION
IAM-1600

This is untested. I need to add the tf plan in https://github.com/canonical/cd-identity-core-infrastructure and deploy that first as it will be creating the secret.
