### PR TITLE
chore: start pinning image version

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -112,7 +112,7 @@ resources:
   oci-image:
     type: oci-image
     description: OCI image for hook-service
-    upstream-source: ghcr.io/canonical/hook-service:main
+    upstream-source: ghcr.io/canonical/hook-service:v1.0.0
 
 parts:
   charm:


### PR DESCRIPTION
This pull request tries to pin the image version to `v1.0.0`, resolving https://github.com/canonical/hook-service-operator/issues/17.